### PR TITLE
Speed up BasketContentsController#index sidebar queries

### DIFF
--- a/app/admin/basket_content.rb
+++ b/app/admin/basket_content.rb
@@ -38,8 +38,7 @@ ActiveAdmin.register BasketContent do
 
   class BasketContentIndex < ActiveAdmin::Views::IndexAsTable
     def build(_page_presenter, collection)
-      if params.dig(:q, :delivery_id_eq).present? && collection.with_unit_price.any?
-        delivery = Delivery.find(params.dig(:q, :delivery_id_eq))
+      if (delivery = helpers.index_delivery) && collection.with_unit_price.any?
         basket_content_prices = delivery.basket_content_prices
         if basket_content_prices.any?
           panel nil do
@@ -60,8 +59,7 @@ ActiveAdmin.register BasketContent do
     params.dig(:q, :delivery_id_eq).present? ? [ :csv, :xlsx ] : [ :csv ]
   }, title: -> {
     title = BasketContent.model_name.human(count: 2)
-    if params.dig(:q, :delivery_id_eq).present?
-      delivery = Delivery.find(params.dig(:q, :delivery_id_eq))
+    if (delivery = index_delivery)
       title += " – #{delivery.display_name}"
     end
     title
@@ -156,11 +154,10 @@ ActiveAdmin.register BasketContent do
   end
 
   sidebar :member_visibility, only: :index, if: -> {
-    params.dig(:q, :delivery_id_eq).present? &&
-      Delivery.find(params.dig(:q, :delivery_id_eq)).coming?
+    index_delivery&.coming?
   } do
     t_scope = "active_admin.basket_contents.member_visibility"
-    delivery = Delivery.find(params.dig(:q, :delivery_id_eq))
+    delivery = index_delivery
 
     settings_action = if authorized?(:update, Organization)
       link_to edit_organization_path(:basket_content), title: t("#{t_scope}.settings") do
@@ -186,28 +183,24 @@ ActiveAdmin.register BasketContent do
 
   sidebar :duplicate_all_to, only: :index, if: -> {
     authorized?(:create, BasketContent)
-      && params.dig(:q, :delivery_id_eq).present?
+      && index_delivery
       && collection.present?
-      && (delivery = Delivery.find(params.dig(:q, :delivery_id_eq)))
-      && BasketContent.coming_deliveries_missing_contents_from(delivery).any?
+      && coming_deliveries_missing_contents.any?
   } do
     side_panel t(".duplicate_all_to") do
-      delivery = Delivery.find(params.dig(:q, :delivery_id_eq))
       render partial: "active_admin/basket_contents/duplicate_all_to",
-        locals: { from_delivery: delivery }
+        locals: { from_delivery: index_delivery, deliveries: coming_deliveries_missing_contents }
     end
   end
 
   sidebar :duplicate_all_from, only: :index, if: -> {
     authorized?(:create, BasketContent)
-      && params.dig(:q, :delivery_id_eq).present?
-      && (delivery = Delivery.find(params.dig(:q, :delivery_id_eq)))
-      && BasketContent.filled_deliveries_with_contents_missing_from(delivery).any?
+      && index_delivery
+      && filled_deliveries_with_contents_missing.any?
   } do
     side_panel t(".duplicate_all_from") do
-      delivery = Delivery.find(params.dig(:q, :delivery_id_eq))
       render partial: "active_admin/basket_contents/duplicate_all_from",
-        locals: { to_delivery: delivery }
+        locals: { to_delivery: index_delivery, deliveries: filled_deliveries_with_contents_missing }
     end
   end
 
@@ -282,13 +275,15 @@ ActiveAdmin.register BasketContent do
     include ApplicationHelper
     include UncachedSendData
 
-    helper_method :initial_distribution_data
+    helper_method :initial_distribution_data,
+      :index_delivery,
+      :coming_deliveries_missing_contents,
+      :filled_deliveries_with_contents_missing
 
     def index
       super do |format|
         format.xlsx do
-          delivery = Delivery.find(params.dig(:q, :delivery_id_eq))
-          xlsx = XLSX::BasketContent.new(delivery)
+          xlsx = XLSX::BasketContent.new(index_delivery)
           send_data xlsx.data,
             content_type: xlsx.content_type,
             filename: xlsx.filename
@@ -320,6 +315,31 @@ ActiveAdmin.register BasketContent do
       distribution[:depots] = Depot.kept.order_by_name
       distribution[:depot_groups] = helpers.admin_depots_grouped_collection
       distribution
+    end
+
+    def index_delivery
+      return @index_delivery if defined?(@index_delivery)
+
+      delivery_id = params.dig(:q, :delivery_id_eq)
+      @index_delivery = delivery_id.present? ? Delivery.find_by(id: delivery_id) : nil
+    end
+
+    def coming_deliveries_missing_contents
+      @coming_deliveries_missing_contents ||=
+        if (delivery = index_delivery)
+          BasketContent.coming_deliveries_missing_contents_from(delivery).to_a
+        else
+          []
+        end
+    end
+
+    def filled_deliveries_with_contents_missing
+      @filled_deliveries_with_contents_missing ||=
+        if (delivery = index_delivery)
+          BasketContent.filled_deliveries_with_contents_missing_from(delivery).to_a
+        else
+          []
+        end
     end
   end
 

--- a/app/models/basket_content.rb
+++ b/app/models/basket_content.rb
@@ -67,23 +67,21 @@ class BasketContent < ApplicationRecord
     source_product_ids = where(delivery_id: delivery_id).distinct.pluck(:product_id)
     return Delivery.none if source_product_ids.empty?
 
-    delivery_ids = Delivery.where(date: after_date..).where.not(id: delivery_id).pluck(:id)
-    delivery_ids.select! { |target_delivery_id|
-      where(delivery_id: target_delivery_id, product_id: source_product_ids).distinct.count(:product_id) < source_product_ids.size
-    }
-    Delivery.where(id: delivery_ids)
+    complete_delivery_ids = where(product_id: source_product_ids)
+      .where(delivery_id: Delivery.where(date: after_date..).where.not(id: delivery_id).select(:id))
+      .group(:delivery_id)
+      .having("COUNT(DISTINCT product_id) = ?", source_product_ids.size)
+      .pluck(:delivery_id)
+
+    Delivery.where(date: after_date..).where.not(id: [ delivery_id, *complete_delivery_ids ])
   end
 
   def self.filled_deliveries_with_contents_missing_from(delivery)
     delivery_id = delivery.id
     target_product_ids = where(delivery_id: delivery_id).distinct.pluck(:product_id)
-    delivery_ids = where.not(delivery_id: delivery_id).distinct.pluck(:delivery_id)
-    if target_product_ids.any?
-      delivery_ids.select! { |source_delivery_id|
-        where(delivery_id: source_delivery_id).where.not(product_id: target_product_ids).exists?
-      }
-    end
-    Delivery.where(id: delivery_ids).reorder(date: :desc)
+    sources = where.not(delivery_id: delivery_id)
+    sources = sources.where.not(product_id: target_product_ids) if target_product_ids.any?
+    Delivery.where(id: sources.distinct.select(:delivery_id)).reorder(date: :desc)
   end
 
   def self.closest_delivery(year = nil)

--- a/app/views/active_admin/basket_contents/_duplicate_all_from.html.erb
+++ b/app/views/active_admin/basket_contents/_duplicate_all_from.html.erb
@@ -1,4 +1,4 @@
-<% deliveries = BasketContent.filled_deliveries_with_contents_missing_from(to_delivery) %>
+<% deliveries ||= BasketContent.filled_deliveries_with_contents_missing_from(to_delivery) %>
 
 <%= form_with url: duplicate_all_basket_contents_path, method: :post, class: "sidebar_form" do |f| %>
   <%= f.hidden_field :to_delivery_id, value: to_delivery.id %>

--- a/app/views/active_admin/basket_contents/_duplicate_all_to.html.erb
+++ b/app/views/active_admin/basket_contents/_duplicate_all_to.html.erb
@@ -1,4 +1,4 @@
-<% deliveries = BasketContent.coming_deliveries_missing_contents_from(from_delivery) %>
+<% deliveries ||= BasketContent.coming_deliveries_missing_contents_from(from_delivery) %>
 
 <%= form_with url: duplicate_all_basket_contents_path, method: :post, class: "sidebar_form" do |f| %>
   <%= f.hidden_field :from_delivery_id, value: from_delivery.id %>

--- a/test/controllers/basket_contents_controller_test.rb
+++ b/test/controllers/basket_contents_controller_test.rb
@@ -96,6 +96,86 @@ class BasketContentsControllerTest < ActionDispatch::IntegrationTest
     refute_includes response.body, BasketContent.human_attribute_name(:quantity)
   end
 
+  test "index shows duplicate_all_to sidebar for later deliveries missing products" do
+    source = deliveries(:monday_1)
+    create_basket_content(
+      product: basket_content_products(:carrots),
+      delivery: source,
+      basket_size_ids_quantities: { small_id => 500 },
+      unit: "kg",
+      unit_price: 2)
+
+    get basket_contents_path(q: { delivery_id_eq: source.id })
+
+    assert_response :success
+    assert_select "form.sidebar_form" do
+      assert_select "input[name='from_delivery_id'][value='#{source.id}']"
+      assert_select "select[name='to_delivery_id'] option[value='#{deliveries(:monday_2).id}']"
+    end
+    assert_select "input[name='to_delivery_id']", count: 0
+  end
+
+  test "index shows duplicate_all_from sidebar when other deliveries have extra products" do
+    target = deliveries(:monday_1)
+    source = deliveries(:monday_2)
+    create_basket_content(
+      product: basket_content_products(:carrots),
+      delivery: target,
+      basket_size_ids_quantities: { small_id => 500 },
+      unit: "kg",
+      unit_price: 2)
+    create_basket_content(
+      product: basket_content_products(:cucumbers),
+      delivery: source,
+      basket_size_ids_quantities: { small_id => 1 },
+      unit: "pc",
+      unit_price: 1.5)
+
+    get basket_contents_path(q: { delivery_id_eq: target.id })
+
+    assert_response :success
+    assert_select "form.sidebar_form" do
+      assert_select "input[name='to_delivery_id'][value='#{target.id}']"
+      assert_select "select[name='from_delivery_id'] option[value='#{source.id}']"
+    end
+  end
+
+  test "index duplicate sidebars do not issue per-delivery basket content existence queries" do
+    target = deliveries(:monday_1)
+    create_basket_content(
+      product: basket_content_products(:carrots),
+      delivery: target,
+      basket_size_ids_quantities: { small_id => 500 },
+      unit: "kg",
+      unit_price: 2)
+    (2..8).each do |i|
+      create_basket_content(
+        product: basket_content_products(:cucumbers),
+        delivery: deliveries(:"monday_#{i}"),
+        basket_size_ids_quantities: { small_id => 1 },
+        unit: "pc",
+        unit_price: 1.5)
+    end
+
+    per_row = []
+    callback = ->(_name, _start, _finish, _id, payload) {
+      sql = payload[:sql]
+      # The old N+1 issued EXISTS per source delivery_id. Ignore the
+      # one-off with_unit_price checks used by the prices panel.
+      if sql.match?(/SELECT 1 AS one FROM ["`]?basket_contents/i) && !sql.include?("unit_price")
+        per_row << sql
+      end
+    }
+
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      get basket_contents_path(q: { delivery_id_eq: target.id })
+    end
+
+    assert_response :success
+    assert_select "select[name='from_delivery_id'] option", minimum: 7
+    assert_empty per_row
+  end
+
   test "edit form renders basket content form frame" do
     bc = create_basket_content(
       basket_size_ids_quantities: { small_id => 500, medium_id => 750 },

--- a/test/models/basket_content_test.rb
+++ b/test/models/basket_content_test.rb
@@ -617,4 +617,85 @@ class BasketContentTest < ActiveSupport::TestCase
     assert_includes deliveries, source_delivery
     assert_not_includes deliveries, to_delivery
   end
+
+  test "coming_deliveries_missing_contents_from does not query per target delivery" do
+    source_delivery = deliveries(:monday_1)
+    create_basket_content(
+      product: basket_content_products(:carrots),
+      delivery: source_delivery,
+      basket_size_ids_quantities: { small_id => 100 },
+      unit: "kg")
+    create_basket_content(
+      product: basket_content_products(:cucumbers),
+      delivery: source_delivery,
+      basket_size_ids_quantities: { small_id => 1 },
+      unit: "pc")
+    create_basket_content(
+      product: basket_content_products(:carrots),
+      delivery: deliveries(:monday_2),
+      basket_size_ids_quantities: { small_id => 100 },
+      unit: "kg")
+    create_basket_content(
+      product: basket_content_products(:carrots),
+      delivery: deliveries(:monday_3),
+      basket_size_ids_quantities: { small_id => 100 },
+      unit: "kg")
+    create_basket_content(
+      product: basket_content_products(:cucumbers),
+      delivery: deliveries(:monday_3),
+      basket_size_ids_quantities: { small_id => 1 },
+      unit: "pc")
+
+    queries = collect_sql_queries {
+      result = BasketContent.coming_deliveries_missing_contents_from(source_delivery).to_a
+      assert_includes result, deliveries(:monday_2)
+      assert_not_includes result, deliveries(:monday_3)
+    }
+
+    assert_no_per_row_basket_content_queries queries
+    assert_operator queries.size, :<=, 3
+  end
+
+  test "filled_deliveries_with_contents_missing_from does not query per source delivery" do
+    to_delivery = deliveries(:monday_1)
+    create_basket_content(
+      product: basket_content_products(:carrots),
+      delivery: to_delivery,
+      basket_size_ids_quantities: { small_id => 100 },
+      unit: "kg")
+    (2..10).each do |i|
+      create_basket_content(
+        product: basket_content_products(:cucumbers),
+        delivery: deliveries(:"monday_#{i}"),
+        basket_size_ids_quantities: { small_id => 1 },
+        unit: "pc")
+    end
+
+    queries = collect_sql_queries {
+      result = BasketContent.filled_deliveries_with_contents_missing_from(to_delivery).to_a
+      assert_equal 9, result.size
+    }
+
+    assert_no_per_row_basket_content_queries queries
+    assert_operator queries.size, :<=, 3
+  end
+
+  private
+
+  def collect_sql_queries
+    queries = []
+    callback = ->(_name, _start, _finish, _id, payload) {
+      sql = payload[:sql]
+      queries << sql unless payload[:name] == "SCHEMA" || sql.match?(/\A(?:BEGIN|COMMIT|SAVEPOINT|RELEASE)/i)
+    }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+    queries
+  end
+
+  def assert_no_per_row_basket_content_queries(queries)
+    per_row = queries.select { |sql|
+      sql.match?(/SELECT 1 AS one FROM ["`]?basket_contents/i)
+    }
+    assert_empty per_row, "expected set-based queries, got: #{per_row.join("\n")}"
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Production evidence

AppSignal (CSA Admin / production), 24–31 Aug 2026 CEST:

- `BasketContentsController#index`: 1,290 requests, p95 **524ms** (prior week 438ms, ~20% slower)
- All sampled traces ≥400ms flagged **N+1**, across tenants (`lafermedugoupil`, `stadsgroenteboer`, `chevreetchou`, `alabellecourgette`)
- Slow samples (deploy `54d5678`): ActiveAdmin layout dominated by `_sidebar.html.erb`
  - `BasketContent Exists?` ~53ms in the sidebar `if:` for **Import** (`filled_deliveries_with_contents_missing_from`)
  - the same `Exists?` ~54ms again in `_duplicate_all_from.html.erb`
  - a cheaper COUNT loop for **Duplicate** (`coming_deliveries_missing_contents_from`) also ran twice
  - `_prices.html.arb` ~90–101ms (`BasketSize#price_for` pluck) — left as a follow-up; not the N+1

Root cause: both helpers looped every candidate delivery and issued a per-row `EXISTS` / `COUNT(DISTINCT product_id)`. ActiveAdmin then evaluated the same helper in the sidebar condition **and** the partial.

## Change

- Rewrite `coming_deliveries_missing_contents_from` and `filled_deliveries_with_contents_missing_from` as set-based queries (one grouped lookup / subquery instead of N+1).
- Memoize the filtered delivery and both result lists on the ActiveAdmin controller; pass them into the duplicate partials so the sidebar `if:` and the select share the same in-memory collection.
- Same UI and options; no copy or workflow changes.

## Tests

Local: `bin/rails test test/models/basket_content_test.rb test/controllers/basket_contents_controller_test.rb`

```
56 runs, 271 assertions, 0 failures, 0 errors, 0 skips
```

- Existing model coverage for the two helpers (empty / partial / complete / empty-target cases).
- New query-count assertions: query volume stays bounded as the number of source/target deliveries grows (no per-row `SELECT 1`).
- Controller tests that both sidebars still render the expected from/to options, and that the index action issues no per-delivery existence queries.

RuboCop on the changed files: no offenses.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60ec1027-9682-4fac-9bd2-79617e51d3e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60ec1027-9682-4fac-9bd2-79617e51d3e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

