### PR TITLE
Retry bank payment import timeouts every 20 minutes

### DIFF
--- a/app/jobs/scheduled/billing_payments_processor_job.rb
+++ b/app/jobs/scheduled/billing_payments_processor_job.rb
@@ -4,7 +4,9 @@ require "net/http"
 
 module Scheduled
   class BillingPaymentsProcessorJob < BaseJob
-    retry_on Net::OpenTimeout, Net::ReadTimeout, wait: 15.minutes, attempts: 5 do |_job, _error|
+    # Must stay on the subclass: ActiveJob matches retry_on last-defined-first, so
+    # this wins over BaseJob's retry_on Exception (short polynomial backoff).
+    retry_on Net::OpenTimeout, Net::ReadTimeout, wait: 20.minutes, attempts: 5 do |_job, _error|
       # The next daily import will retrieve any payments missed during the outage.
     end
 

--- a/test/jobs/scheduled/billing_payments_processor_job_test.rb
+++ b/test/jobs/scheduled/billing_payments_processor_job_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 require "minitest/mock"
 
 class Scheduled::BillingPaymentsProcessorJobTest < ActiveJob::TestCase
-  test "retries HTTP timeouts every 15 minutes then discards" do
+  test "retries HTTP timeouts every 20 minutes then discards" do
     attempts = 0
     import = -> {
       attempts += 1
@@ -17,8 +17,8 @@ class Scheduled::BillingPaymentsProcessorJobTest < ActiveJob::TestCase
         perform_enqueued_jobs
 
         retry_delay = enqueued_jobs.sole.fetch(:at) - Time.current.to_f
-        assert_operator retry_delay, :>=, 15.minutes.to_i
-        assert_operator retry_delay, :<=, 18.minutes.to_i
+        assert_operator retry_delay, :>=, 20.minutes.to_i
+        assert_operator retry_delay, :<=, 23.minutes.to_i
 
         4.times { perform_enqueued_jobs }
       end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Overnight BAS HTTP timeouts (CSA Admin production, [incident #667](https://appsignal.com/csa-admin/sites/672e0b61d2a5e4b5197f10e4/exceptions/incidents/667)) still exhaust `Scheduled::BillingPaymentsProcessorJob` after 5 attempts. On 1 Sep 2026 for tenant `lumieredeschamps`, a sample was queued at 04:49 and ran at 05:05 Zurich (~16 minutes) during `Billing::BAS#autologin`.

**Why 20 minutes:** the existing 15-minute wait already applies (that 16-minute hop matches 15 minutes plus jitter, not BaseJob’s polynomial ~3s/18s/83s curve). Four intervals still only cover about an hour from the 4am recurring run, and the 5th attempt still timed out. Spacing attempts by 20 minutes (~80 minutes total) gives BAS more time to recover before we discard; the next daily import still picks up any missed payments.

**Why the subclass handler must win:** `Scheduled::BaseJob` declares `retry_on Exception, wait: :polynomially_longer, attempts: 5`. ActiveJob/`rescue_from` searches last-defined first, so the more specific `Net::OpenTimeout` / `Net::ReadTimeout` handler has to stay on the subclass. That is what selects the long wait instead of BaseJob’s short retries. Other exceptions keep the BaseJob behavior.

- Keep 5 attempts, then discard
- Update the job test to expect 20–23 minutes (same jitter tolerance as the old 15–18 assertion)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8a500fe-65f7-4aed-b09b-c228ed0ec14b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8a500fe-65f7-4aed-b09b-c228ed0ec14b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

