### PR TITLE
Return 404 when Active Storage image variants cannot be processed

### DIFF
--- a/config/initializers/active_storage_representations.rb
+++ b/config/initializers/active_storage_representations.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Variant generation raises Vips::Error when a blob is labeled as an image
+# but the bytes are not a format libvips can load (AppSignal #458).
+# after_initialize: the gem controller is not loaded while initializers run.
+Rails.application.config.after_initialize do
+  ActiveStorage::Representations::BaseController.class_eval do
+    private
+
+    def set_representation
+      @representation = @blob.representation(params[:variation_key]).processed
+    rescue ActiveSupport::MessageVerifier::InvalidSignature, Vips::Error, ImageProcessing::Error
+      head :not_found
+    end
+  end
+end

--- a/test/controllers/active_storage/representations_controller_test.rb
+++ b/test/controllers/active_storage/representations_controller_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorage::RepresentationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "admin.acme.test"
+  end
+
+  test "returns not found when the blob is not a loadable image" do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("#{png_signature}truncated"),
+      filename: "broken.png",
+      content_type: "image/png")
+
+    get newsletter_representation_path(blob)
+
+    assert_response :not_found
+  end
+
+  test "redirects a valid image representation to the storage service" do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("logo.png").open,
+      filename: "logo.png",
+      content_type: "image/png")
+
+    get newsletter_representation_path(blob)
+
+    assert_redirected_to %r{\Ahttp://admin\.acme\.test/rails/active_storage/disk/}
+  end
+
+  private
+
+  def png_signature
+    [ "89504E470D0A1A0A" ].pack("H*")
+  end
+
+  # Same JPEG variant as app/views/active_storage/blobs/_blob.html.erb
+  # (newsletter / Trix attachments).
+  def newsletter_representation_path(blob)
+    rails_representation_path(
+      blob.representation(
+        resize_to_limit: [ 1024, 768 ],
+        format: :jpeg,
+        saver: { quality: 80, background: [ 255, 255, 255 ] }))
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Production AppSignal exception [incident #458](https://appsignal.com/csa-admin/sites/672e0b61d2a5e4b5197f10e4/exceptions/incidents/458) is a `Vips::Error` from `ActiveStorage::Representations::RedirectController#show`:

```
VipsForeignLoad: "/tmp/ActiveStorage-….png" is not a known file format
```

Recent traces (tenant `ragedevert`, blobs ~9548 and ~9549) 500 while transforming the blob to the newsletter/Trix JPEG variant (`resize_to_limit: [1024, 768]`, matching `app/views/active_storage/blobs/_blob.html.erb`).

The blob is stored/named as an image, so Active Storage treats it as representable, but the bytes are not a format libvips can load (corrupt, truncated, or not actually an image). Rails already returns 404 for an invalid variation signature; this extends that to failed image processing.

Upload-time validation alone would not stop the 500s: these blobs already exist, Trix only checks the browser-reported MIME type, and org logos already validate bytes with Vips. This keeps the existing images in place and makes their representation URLs fail closed.

## What

- Reopen `ActiveStorage::Representations::BaseController#set_representation` after boot and rescue `Vips::Error` / `ImageProcessing::Error` next to the existing `InvalidSignature` handler (`head :not_found`).
- `after_initialize` (not `to_prepare` + prepend): the gem controller is not loaded while initializers run, and gem controllers do not reload.
- Cover the newsletter JPEG variant: corrupt PNG header → 404; valid PNG → disk redirect.

Do not merge or deploy from this PR. Leave the AppSignal incident open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9b8d210-e3c2-414e-9b72-a39c56f3c57b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9b8d210-e3c2-414e-9b72-a39c56f3c57b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

