### PR TITLE
Return 404 when Active Storage representation blobs are missing

### DIFF
--- a/config/initializers/active_storage_representations.rb
+++ b/config/initializers/active_storage_representations.rb
@@ -2,6 +2,8 @@
 
 # Variant generation raises Vips::Error when a blob is labeled as an image
 # but the bytes are not a format libvips can load (AppSignal #458).
+# Preview/variant processing raises FileNotFoundError when the blob record
+# exists but the object is missing from storage (AppSignal #370).
 # after_initialize: the gem controller is not loaded while initializers run.
 Rails.application.config.after_initialize do
   ActiveStorage::Representations::BaseController.class_eval do
@@ -9,7 +11,7 @@ Rails.application.config.after_initialize do
 
     def set_representation
       @representation = @blob.representation(params[:variation_key]).processed
-    rescue ActiveSupport::MessageVerifier::InvalidSignature, Vips::Error, ImageProcessing::Error
+    rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveStorage::FileNotFoundError, Vips::Error, ImageProcessing::Error
       head :not_found
     end
   end

--- a/test/controllers/active_storage/representations_controller_test.rb
+++ b/test/controllers/active_storage/representations_controller_test.rb
@@ -18,6 +18,18 @@ class ActiveStorage::RepresentationsControllerTest < ActionDispatch::Integration
     assert_response :not_found
   end
 
+  test "returns not found when the stored blob is missing" do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("logo.png").open,
+      filename: "logo.png",
+      content_type: "image/png")
+    blob.service.delete(blob.key)
+
+    get newsletter_representation_path(blob)
+
+    assert_response :not_found
+  end
+
   test "redirects a valid image representation to the storage service" do
     blob = ActiveStorage::Blob.create_and_upload!(
       io: file_fixture("logo.png").open,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Production AppSignal exception [incident #370](https://appsignal.com/csa-admin/sites/672e0b61d2a5e4b5197f10e4/exceptions/incidents/370) is an `ActiveStorage::FileNotFoundError` from `ActiveStorage::Representations::RedirectController#show`:

```
S3Service#stream/download → Blob#open → PopplerPDFPreviewer#preview → Preview#processed → set_representation
```

Recent traces (rev `1811e08`, tenants such as `demo-de`, blob id 131) 500 on `GET representations/redirect` because the blob record exists but the object is missing from S3. Rails already returns 404 for an invalid variation signature and for unprocessable image bytes (PR #172 / AppSignal #458); a missing storage object still raised.

## What

- Rescue `ActiveStorage::FileNotFoundError` next to `InvalidSignature` / `Vips::Error` / `ImageProcessing::Error` in `ActiveStorage::Representations::BaseController#set_representation` (`head :not_found`).
- Same `after_initialize` + `class_eval` style as PR #172 (gem controller is not loaded while initializers run).
- Cover a stored blob whose file was deleted: representation request → 404.

Do not merge or deploy from this PR. Leave the AppSignal incident open.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18ce73e5-9b64-4474-809e-54dc182f4cd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18ce73e5-9b64-4474-809e-54dc182f4cd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

