### PR TITLE
Ensure demo-seeded invoice PDFs are present on storage

### DIFF
--- a/app/models/demo/seeder.rb
+++ b/app/models/demo/seeder.rb
@@ -191,6 +191,7 @@ class Demo::Seeder
       seed_activities!
       seed_shop!
     end
+    ensure_invoice_pdfs_uploaded!
     mark_deliveries_delivered!
     SearchEntry.rebuild!
 
@@ -1206,6 +1207,32 @@ class Demo::Seeder
 
       template.deliver!(membership: membership)
     end
+  end
+
+  # Active Storage persists blob/attachment rows in after_save and
+  # uploads in after_commit. Seed wraps invoice.process! / attach_pdf
+  # in a transaction, so uploads wait until that block commits. A reload
+  # on the same invoice instance (shop historical orders do this) clears
+  # attachment_changes and the after_commit upload is skipped — DB row,
+  # missing object key (Rails #57222). Invoice#pdf_current? is only
+  # !pdf_stale? for Other invoices and still true for an attached orphan,
+  # so admin preview would raise without this (AppSignal #370 / demo-de).
+  # Re-attach outside the transaction so the upload is synchronous.
+  def ensure_invoice_pdfs_uploaded!
+    log "Ensuring invoice PDFs are on storage..."
+
+    Invoice.with_attached_pdf_file.find_each do |invoice|
+      next if invoice_pdf_on_storage?(invoice)
+
+      invoice.attach_pdf
+    end
+  end
+
+  def invoice_pdf_on_storage?(invoice)
+    return false unless invoice.pdf_file.attached?
+
+    blob = invoice.pdf_file.blob
+    blob.service.exist?(blob.key)
   end
 
   # Must run outside of transaction so after_create_commit on

--- a/app/models/demo/seeder.rb
+++ b/app/models/demo/seeder.rb
@@ -1221,7 +1221,7 @@ class Demo::Seeder
   def ensure_invoice_pdfs_uploaded!
     log "Ensuring invoice PDFs are on storage..."
 
-    Invoice.with_attached_pdf_file.find_each do |invoice|
+    Invoice.joins(:pdf_file_attachment).with_attached_pdf_file.find_each do |invoice|
       next if invoice_pdf_on_storage?(invoice)
 
       invoice.attach_pdf
@@ -1229,10 +1229,8 @@ class Demo::Seeder
   end
 
   def invoice_pdf_on_storage?(invoice)
-    return false unless invoice.pdf_file.attached?
-
     blob = invoice.pdf_file.blob
-    blob.service.exist?(blob.key)
+    blob.present? && blob.service.exist?(blob.key)
   end
 
   # Must run outside of transaction so after_create_commit on

--- a/test/models/demo/seeder_test.rb
+++ b/test/models/demo/seeder_test.rb
@@ -128,6 +128,46 @@ class Demo::SeederTest < ActiveSupport::TestCase
     end
   end
 
+  test "ensure_invoice_pdfs_uploaded! re-attaches when the blob row exists but the file does not" do
+    enable_invoice_pdf
+    with_demo_tenant do
+      invoice = create_other_invoice(amount: 10)
+      blob = invoice.pdf_file.blob
+      blob.service.delete(blob.key)
+
+      assert invoice.pdf_file.attached?
+      assert_not blob.service.exist?(blob.key)
+      assert invoice.pdf_current?
+
+      Demo::Seeder.new.send(:ensure_invoice_pdfs_uploaded!)
+      invoice.reload
+
+      assert invoice.pdf_file.attached?
+      assert invoice.pdf_file.blob.service.exist?(invoice.pdf_file.blob.key)
+      assert_not_equal blob.id, invoice.pdf_file.blob_id
+      assert_not invoice.pdf_stale?
+      assert invoice.pdf_current?
+      assert invoice.can_send_email?
+      assert invoice.pdf_file.download.present?
+    end
+  end
+
+  test "ensure_invoice_pdfs_uploaded! leaves present invoice PDFs in place" do
+    enable_invoice_pdf
+    with_demo_tenant do
+      invoice = create_other_invoice(amount: 10)
+      blob_id = invoice.pdf_file.blob_id
+
+      Demo::Seeder.new.send(:ensure_invoice_pdfs_uploaded!)
+      invoice.reload
+
+      assert_equal blob_id, invoice.pdf_file.blob_id
+      assert invoice.pdf_file.blob.service.exist?(invoice.pdf_file.blob.key)
+      assert invoice.pdf_current?
+      assert invoice.can_send_email?
+    end
+  end
+
   private
 
   def prepare_membership_seeder


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Production AppSignal exception [incident #370](https://appsignal.com/csa-admin/sites/672e0b61d2a5e4b5197f10e4/exceptions/incidents/370) is an `ActiveStorage::FileNotFoundError` on tenant `demo-de` (blob id 131). Admin invoice show preview (`_invoice_preview.html.erb`) calls `invoice.pdf_file.preview` when `invoice.pdf_current? && !invoice.processing?`. The attachment row existed; the S3 object key did not.

This is separate from:

- **PR #173** (merged) — FileNotFoundError → 404 on representations. Defense in depth for the request path; it does not stop the seeder from creating orphans.
- **`pdf_stale` / Send-button fixes** (`6cf1408`, `b8a4a3a`, `1811e08`) — those keep Other invoices sendable around Active Storage `updated_at` touches. `pdf_current?` is `!pdf_stale?` when attached, so an orphan blob with `pdf_stale: false` still offers the preview. Timing alone would not have prevented #370.

`ChoresJob#purge_unattached_active_storage_blobs!` only purges *unattached* blobs older than a week, so this attached orphan stays.

## What

Demo seed wraps `invoice.process!` → `attach_pdf` in a transaction (`create_other_invoices!`, `seed_historical_shop_orders!`). On Rails 8.1, Active Storage persists blob/attachment rows in `after_save` and uploads in `after_commit`. A `reload` on the same invoice instance before commit (shop historical orders do this) clears `attachment_changes` and skips the upload — DB row, missing object key ([Rails #57222](https://github.com/rails/rails/issues/57222)).

After the seed transaction:

1. Check each attached invoice `pdf_file` with `blob.service.exist?(blob.key)` (works for `tenant_object_store` / TenantS3 in production and Disk in test).
2. Re-call `Invoice#attach_pdf` outside the transaction when the key is missing, so the upload is synchronous and `pdf_stale` stays false.

`mark_deliveries_delivered!` still rescues `FileNotFoundError` as a safety net (same class of race, added in `066e96c`). ChoresJob purge rules are unchanged.

## Tests

- Re-attach when the blob row exists but the file does not; `pdf_current?` / sendability stay true.
- Leave present PDFs in place (same blob id).

Do not merge or deploy from this PR. Leave the AppSignal incident open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-939f0439-6a48-4c94-bb53-49cb26132b5d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-939f0439-6a48-4c94-bb53-49cb26132b5d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

