### PR TITLE
Speed up members newsletter list by paginating MailDelivery loads

### DIFF
--- a/app/controllers/members/newsletter_deliveries_controller.rb
+++ b/app/controllers/members/newsletter_deliveries_controller.rb
@@ -7,10 +7,14 @@ class Members::NewsletterDeliveriesController < Members::BaseController
 
   def index
     offset = params[:offset].to_i
-    @deliveries = Newsletter.deliveries_for(current_member)
-    @next_offset = offset + PER_PAGE
-    @next_offset = nil unless @deliveries.count > @next_offset
-    @deliveries = @deliveries.offset(offset).first(PER_PAGE)
+    page = Newsletter.deliveries_for(current_member)
+      .without_content
+      .offset(offset)
+      .limit(PER_PAGE + 1)
+      .to_a
+
+    @next_offset = offset + PER_PAGE if page.size > PER_PAGE
+    @deliveries = page.first(PER_PAGE)
   end
 
   def show

--- a/app/models/mail_delivery.rb
+++ b/app/models/mail_delivery.rb
@@ -11,11 +11,14 @@ class MailDelivery < ApplicationRecord
   has_states :draft, :processing, :delivered, :partially_delivered, :not_delivered
 
   belongs_to :member
+  belongs_to :source_newsletter, class_name: "Newsletter",
+    foreign_key: :mailable_id, optional: true
   has_many :emails, class_name: "MailDelivery::Email", dependent: :destroy
 
   scope :processed, -> { where.not(state: [ :draft, :processing ]) }
   scope :newsletters, -> { where(mailable_type: "Newsletter") }
   scope :mail_templates, -> { where.not(mailable_type: "Newsletter") }
+  scope :without_content, -> { select(*(column_names - [ "content" ])) }
   scope :with_email, ->(email) {
     joins(:emails).merge(Email.with_email(email))
   }
@@ -120,7 +123,7 @@ class MailDelivery < ApplicationRecord
 
   def source
     @source ||= if newsletter?
-      mailables.first
+      source_newsletter
     else
       MailTemplate.find_by!(title: mail_template_title)
     end

--- a/app/models/newsletter/delivery.rb
+++ b/app/models/newsletter/delivery.rb
@@ -17,16 +17,12 @@ class Newsletter
 
     class_methods do
       def deliveries_for(member)
-        deliveries =
-          MailDelivery
-            .newsletters
-            .processed
-            .where(member: member)
-            .order(created_at: :desc)
-        newsletter_ids = deliveries.flat_map(&:mailable_ids).uniq
-        newsletters = Newsletter.where(id: newsletter_ids).index_by(&:id)
-        deliveries.each { |d| d.preload_source!(newsletters[d.mailable_ids.first]) }
-        deliveries
+        MailDelivery
+          .newsletters
+          .processed
+          .where(member: member)
+          .includes(:source_newsletter)
+          .order(created_at: :desc)
       end
     end
 

--- a/db/migrate/20260907120000_add_member_newsletter_list_index_to_mail_deliveries.rb
+++ b/db/migrate/20260907120000_add_member_newsletter_list_index_to_mail_deliveries.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddMemberNewsletterListIndexToMailDeliveries < ActiveRecord::Migration[8.1]
+  def change
+    add_index :mail_deliveries, [ :member_id, :mailable_type, :created_at ],
+      name: "idx_mail_deliveries_on_member_mailable_created"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_02_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_07_120000) do
   create_table "absences", force: :cascade do |t|
     t.datetime "admins_notified_at"
     t.datetime "created_at"
@@ -631,6 +631,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_120000) do
     t.index ["mailable_type", "mailable_id"], name: "idx_mail_deliveries_on_mailable_type_id"
     t.index ["mailable_type", "mailable_ids", "member_id"], name: "idx_mail_deliveries_on_mailable_member"
     t.index ["member_id", "created_at"], name: "idx_mail_deliveries_on_member_created"
+    t.index ["member_id", "mailable_type", "created_at"], name: "idx_mail_deliveries_on_member_mailable_created"
     t.index ["member_id"], name: "index_mail_deliveries_on_member_id"
     t.index ["state"], name: "index_mail_deliveries_on_state"
     t.check_constraint "JSON_TYPE(mailable_ids) = 'array'", name: "mail_deliveries_mailable_ids_is_array"

--- a/test/controllers/members/newsletter_deliveries_controller_test.rb
+++ b/test/controllers/members/newsletter_deliveries_controller_test.rb
@@ -7,6 +7,16 @@ class Members::NewsletterDeliveriesControllerTest < ActionDispatch::IntegrationT
     host! "members.acme.test"
   end
 
+  def login(member)
+    session = Session.create!(
+      member: member,
+      email: member.emails_array.first,
+      remote_addr: "127.0.0.1",
+      user_agent: "Test Browser")
+    get "/sessions/#{session.generate_token_for(:redeem)}"
+    session
+  end
+
   def login_as_admin_originated(member, admin: admins(:ultra))
     session = Session.create!(
       admin: admin,
@@ -16,6 +26,56 @@ class Members::NewsletterDeliveriesControllerTest < ActionDispatch::IntegrationT
       user_agent: "Test Browser")
     get "/sessions/#{session.generate_token_for(:redeem)}"
     session
+  end
+
+  test "index lists the latest processed newsletter deliveries" do
+    login(members(:john))
+
+    get members_newsletter_deliveries_path
+
+    assert_response :success
+    assert_select ".newsletter-title", text: "Subject John Doe"
+    assert_select ".newsletter-date", text: /1 April 2024/
+  end
+
+  test "index query count stays bounded as newsletter deliveries grow" do
+    member = members(:john)
+    login(member)
+
+    create_newsletter_deliveries!(member, 25)
+    few_queries = collect_sql_queries { get members_newsletter_deliveries_path }
+    assert_response :success
+    assert_bounded_newsletter_index_queries(few_queries)
+
+    create_newsletter_deliveries!(member, 40, start_at: 1.hour.ago)
+    many_queries = collect_sql_queries { get members_newsletter_deliveries_path }
+    assert_response :success
+    assert_bounded_newsletter_index_queries(many_queries)
+
+    assert_equal query_signatures(few_queries).size, query_signatures(many_queries).size
+    assert_equal newsletter_loads(few_queries).size, newsletter_loads(many_queries).size
+    assert_equal mail_delivery_loads(few_queries).size, mail_delivery_loads(many_queries).size
+  end
+
+  test "index paginates without loading every delivery" do
+    member = members(:john)
+    login(member)
+    create_newsletter_deliveries!(
+      member,
+      Members::NewsletterDeliveriesController::PER_PAGE,
+      start_at: 1.hour.from_now)
+
+    get members_newsletter_deliveries_path
+
+    assert_response :success
+    assert_select ".newsletter-title", text: "Extra 0"
+    assert_select ".newsletter-title", text: "Subject John Doe", count: 0
+    assert_select "#show-more a[href*='offset=20']"
+
+    get members_newsletter_deliveries_path(offset: 20, format: :turbo_stream)
+
+    assert_response :success
+    assert_includes response.body, "Subject John Doe"
   end
 
   test "index shows the member email in the unsubscribe banner for an admin-originated session" do
@@ -51,5 +111,74 @@ class Members::NewsletterDeliveriesControllerTest < ActionDispatch::IntegrationT
 
     assert_redirected_to members_newsletter_deliveries_path
     assert_equal I18n.t("members.read_only_sessions.alert"), flash[:alert]
+  end
+
+  private
+
+  def create_newsletter_deliveries!(member, count, start_at: Time.current)
+    newsletter = newsletters(:sent)
+    rows = count.times.map { |i|
+      {
+        mailable_type: "Newsletter",
+        mailable_ids: [ newsletter.id ],
+        action: "newsletter",
+        member_id: member.id,
+        subject: "Extra #{i}",
+        state: "delivered",
+        content: "<html>#{"x" * 2_000}</html>",
+        created_at: start_at - i.minutes,
+        updated_at: start_at - i.minutes
+      }
+    }
+    MailDelivery.insert_all(rows)
+  end
+
+  def collect_sql_queries
+    queries = []
+    callback = ->(_name, _start, _finish, _id, payload) {
+      sql = payload[:sql]
+      queries << sql unless payload[:name] == "SCHEMA" || sql.match?(/\A(?:BEGIN|COMMIT|SAVEPOINT|RELEASE)/i)
+    }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+    queries
+  end
+
+  def mail_delivery_loads(queries)
+    queries.select { |sql|
+      sql.match?(/SELECT .+FROM ["`]mail_deliveries["`]/i) &&
+        !sql.match?(/SELECT 1 AS one/i) &&
+        !sql.match?(/COUNT\(/i)
+    }
+  end
+
+  def newsletter_loads(queries)
+    queries.select { |sql| sql.match?(/SELECT .+FROM ["`]newsletters["`]/i) }
+  end
+
+  def query_signatures(queries)
+    (mail_delivery_loads(queries) + newsletter_loads(queries)).map { |sql|
+      sql.gsub(/\d+/, "N")
+    }
+  end
+
+  def assert_bounded_newsletter_index_queries(queries)
+    loads = mail_delivery_loads(queries)
+    assert_operator loads.size, :<=, 2,
+      "expected bounded MailDelivery loads, got:\n#{loads.join("\n")}"
+    loads.each do |sql|
+      assert_match(/LIMIT/i, sql)
+    end
+
+    page_loads = loads.select { |sql| sql.match?(/OFFSET/i) }
+    assert_equal 1, page_loads.size, "expected one paginated MailDelivery load, got:\n#{loads.join("\n")}"
+    page_loads.each do |sql|
+      assert_no_match(/\bSELECT\s+(?:["`]?\w+["`]?\.)?\*/i, sql)
+      assert_match(/["`]subject["`]/, sql)
+      assert_no_match(/["`]content["`]/, sql)
+    end
+
+    newsletter_sql = newsletter_loads(queries)
+    assert_operator newsletter_sql.size, :<=, 2,
+      "expected bounded Newsletter loads, got:\n#{newsletter_sql.join("\n")}"
   end
 end

--- a/test/models/newsletter/delivery_test.rb
+++ b/test/models/newsletter/delivery_test.rb
@@ -162,6 +162,30 @@ class NewsletterDeliveryTest < ActiveSupport::TestCase
     end
   end
 
+  test "deliveries_for uses the member newsletter list index" do
+    columns = ActiveRecord::Base.connection.indexes(:mail_deliveries).map(&:columns)
+    assert_includes columns, %w[member_id mailable_type created_at]
+
+    sql = Newsletter.deliveries_for(members(:john)).limit(21).to_sql
+    plan = ActiveRecord::Base.connection.exec_query("EXPLAIN QUERY PLAN #{sql}").rows.flatten.join(" ")
+    assert_match(/idx_mail_deliveries_on_member_mailable_created/, plan)
+  end
+
+  test "deliveries_for is an unloaded relation of processed newsletter deliveries" do
+    draft = MailDelivery.create!(
+      mailable_type: "Newsletter",
+      mailable_ids: [ newsletters(:sent).id ],
+      action: "newsletter",
+      member: members(:john),
+      subject: "Draft",
+      state: :draft)
+    relation = Newsletter.deliveries_for(members(:john))
+
+    assert_not relation.loaded?
+    assert_includes relation, mail_deliveries(:sent_john)
+    assert_not_includes relation, draft
+  end
+
   test "deliveries_with_missing_emails" do
     travel_to "2024-01-01"
     newsletter = build_newsletter(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

AppSignal production traces for `Members::NewsletterDeliveriesController#index` (`/newsletters`) show a p95 regression (~217ms → ~363ms) with slow samples of 0.8–1.4s across tenants.

On a 1447ms sample (stadsgroenteboer, rev `0760de0…`), the 1313.7ms hotspot SQL is:

```sql
SELECT "mail_deliveries".* FROM "mail_deliveries"
WHERE "mail_deliveries"."mailable_type" = ?
  AND "mail_deliveries"."state" NOT IN (?, ?)
  AND "mail_deliveries"."member_id" = ?
ORDER BY "mail_deliveries"."created_at" DESC
```

No `LIMIT`. This matches `Newsletter.deliveries_for`, which loaded **every** processed newsletter delivery for the member (including HTML `content`) before the controller paginated. That second page query also dropped the in-memory newsletter preload, so `_newsletter.html.erb` N+1’d `Newsletter` per row.

## Change

1. **Paginate first.** `deliveries_for` is now an unloaded relation. The index action loads one page + 1 (`LIMIT 21`) to decide “show more”, and omits `content`.
2. **Index the list/exists shape.** Added `idx_mail_deliveries_on_member_mailable_created` on `(member_id, mailable_type, created_at)`. A leading `state` column (as in `(member_id, mailable_type, state, created_at)`) made SQLite keep using the older `(member_id, created_at)` index for `ORDER BY created_at`; EXPLAIN confirms the three-column index is used. `state NOT IN (draft, processing)` is applied after the seek.
3. **Eager-load Newsletter.** `MailDelivery` belongs to `source_newsletter` via the virtual `mailable_id` column. `deliveries_for` uses `includes(:source_newsletter)`, so the collection partial does not query per row.

Behavior/UI is unchanged: same 20-item list, same “show more” offset pagination, same processed-only filter.

## Tests

- Index still renders the latest processed deliveries and paginates.
- Query count stays bounded when delivery count grows (25 → 65): the paginated `MailDelivery` load must be an explicit column list with `LIMIT`/`OFFSET`, include `subject`, and omit `content` (a `SELECT *` fails this check).
- EXPLAIN QUERY PLAN uses the new index for `deliveries_for`.

## Review follow-up

Dropped unused `Newsletter.preload_sources!` (admin still inlines its own preload). Removed the dead `Extra 24` pagination assertion. Tightened the content-omit SQL check so `SELECT *` fails.

## Notes

The `MailDelivery Exists?` gate is unchanged. The large win is avoiding the unbounded `SELECT *`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81220d63-c0a1-451e-b194-13333ebe22c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81220d63-c0a1-451e-b194-13333ebe22c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

