### PR TITLE
Enrich AppSignal discard context after payment import timeouts

### DIFF
--- a/app/jobs/scheduled/billing_payments_processor_job.rb
+++ b/app/jobs/scheduled/billing_payments_processor_job.rb
@@ -32,7 +32,7 @@ module Scheduled
         connection: Current.org.active_bank_connection,
         operation_kind: "payment_import",
         executions: executions)
-      Appsignal.add_tags(**context)
+      Appsignal.add_tags(context)
     end
   end
 end

--- a/app/jobs/scheduled/billing_payments_processor_job.rb
+++ b/app/jobs/scheduled/billing_payments_processor_job.rb
@@ -6,12 +6,33 @@ module Scheduled
   class BillingPaymentsProcessorJob < BaseJob
     # Must stay on the subclass: ActiveJob matches retry_on last-defined-first, so
     # this wins over BaseJob's retry_on Exception (short polynomial backoff).
-    retry_on Net::OpenTimeout, Net::ReadTimeout, wait: 20.minutes, attempts: 5 do |_job, _error|
-      # The next daily import will retrieve any payments missed during the outage.
+    # Mid-retries stay quiet: report: false (ActiveJob default) plus
+    # activejob_report_errors = "discard" (AppSignal only set_error on after_discard).
+    retry_on Net::OpenTimeout, Net::ReadTimeout, wait: 20.minutes, attempts: 5, report: false do |job, _error|
+      # Discard after the last attempt so the next daily import can catch up.
+      # AppSignal's after_discard hook reports that exhausted timeout once;
+      # only enrich the current transaction so that sample is useful.
+      job.tag_exhausted_timeout
     end
 
     def perform
       Billing::PaymentsProcessor.retrieve_and_process!
+    end
+
+    def tag_exhausted_timeout
+      # retry_on runs outside TenantContext's around_perform, so re-enter the
+      # serialized tenant before reading Current.org / bank connection.
+      with_context { tag_timeout_in_tenant }
+    end
+
+    private
+
+    def tag_timeout_in_tenant
+      context = Billing::EBICS::SafeContext.build(
+        connection: Current.org.active_bank_connection,
+        operation_kind: "payment_import",
+        executions: executions)
+      Appsignal.add_tags(**context)
     end
   end
 end

--- a/test/jobs/scheduled/billing_payments_processor_job_test.rb
+++ b/test/jobs/scheduled/billing_payments_processor_job_test.rb
@@ -12,9 +12,7 @@ class Scheduled::BillingPaymentsProcessorJobTest < ActiveJob::TestCase
       attempts += 1
       raise Net::ReadTimeout
     }
-    capture_tags = ->(*args, **kwargs) {
-      tagged << (args.first || {}).merge(kwargs).stringify_keys
-    }
+    capture_tags = ->(tags = {}) { tagged << tags.stringify_keys }
 
     travel_to Time.zone.local(2026, 7, 27, 4) do
       Billing::PaymentsProcessor.stub(:retrieve_and_process!, import) do

--- a/test/jobs/scheduled/billing_payments_processor_job_test.rb
+++ b/test/jobs/scheduled/billing_payments_processor_job_test.rb
@@ -4,27 +4,48 @@ require "test_helper"
 require "minitest/mock"
 
 class Scheduled::BillingPaymentsProcessorJobTest < ActiveJob::TestCase
-  test "retries HTTP timeouts every 20 minutes then discards" do
+  test "retries HTTP timeouts every 20 minutes then tags once and discards" do
+    recorder = ErrorRecorder.new
+    tagged = []
     attempts = 0
     import = -> {
       attempts += 1
       raise Net::ReadTimeout
     }
+    capture_tags = ->(*args, **kwargs) {
+      tagged << (args.first || {}).merge(kwargs).stringify_keys
+    }
 
     travel_to Time.zone.local(2026, 7, 27, 4) do
       Billing::PaymentsProcessor.stub(:retrieve_and_process!, import) do
-        Scheduled::BillingPaymentsProcessorJob.perform_later
-        perform_enqueued_jobs
+        Appsignal.stub(:add_tags, capture_tags) do
+          with_rails_error(recorder) do
+            Scheduled::BillingPaymentsProcessorJob.perform_later
+            perform_enqueued_jobs
 
-        retry_delay = enqueued_jobs.sole.fetch(:at) - Time.current.to_f
-        assert_operator retry_delay, :>=, 20.minutes.to_i
-        assert_operator retry_delay, :<=, 23.minutes.to_i
+            retry_delay = enqueued_jobs.sole.fetch(:at) - Time.current.to_f
+            assert_operator retry_delay, :>=, 20.minutes.to_i
+            assert_operator retry_delay, :<=, 23.minutes.to_i
+            assert_empty recorder.reports
+            assert_empty tagged
 
-        4.times { perform_enqueued_jobs }
+            3.times { perform_enqueued_jobs }
+            assert_empty recorder.reports
+            assert_empty tagged
+            assert_enqueued_jobs 1
+
+            perform_enqueued_jobs
+          end
+        end
       end
     end
 
     assert_equal 5, attempts
     assert_no_enqueued_jobs
+    assert_empty recorder.reports
+    assert_equal 1, tagged.size
+    assert_equal "acme", tagged.first["tenant"]
+    assert_equal 5, tagged.first["executions"]
+    assert_equal "payment_import", tagged.first["operation_kind"]
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Overnight BAS HTTP timeouts still surface as [AppSignal #667](https://appsignal.com/csa-admin/sites/672e0b61d2a5e4b5197f10e4/exceptions/incidents/667) after `Scheduled::BillingPaymentsProcessorJob` exhausts its retries.

**Reporting path (single sample on exhaust):**
- `retry_on Net::OpenTimeout, Net::ReadTimeout, wait: 20.minutes, attempts: 5, report: false` — ActiveJob does not call `Rails.error.report` on attempts 1–4 (`report: false` is also the default; set explicitly for clarity).
- `config.activejob_report_errors = "discard"` — AppSignal only `set_error` on ActiveJob `after_discard`. Mid-retries stay quiet.
- Rails 8.1 still runs `run_after_discard_procs` after a `retry_on` block, so AppSignal already reports **once** when the 5th attempt fails.
- The exhaust block does **not** call `Rails.error.report` (that would duplicate the discard sample). It re-enters tenant context and `Appsignal.add_tags` with `Billing::EBICS::SafeContext` (connection, `operation_kind: payment_import`, `executions`) so that one discard report is useful.
- Job is discarded (no re-raise) so Solid Queue does not keep a failed job; the next daily import can catch up.

LoginError / UnknownError handling is unchanged (health + mail, no raise). `mark_error!` on timeouts stays. BAS HTTP timeouts stay at 20s.

**Out of scope:** no merge, no deploy, no AppSignal incident close, no bank-side changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bea981b0-0852-44d3-8152-8038f4f4d7c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bea981b0-0852-44d3-8152-8038f4f4d7c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

